### PR TITLE
SEO: fix redirects

### DIFF
--- a/_data/navigation/docs.yml
+++ b/_data/navigation/docs.yml
@@ -3,11 +3,11 @@
     - title: "Quick-Start Guide"
       url: /docs/quick-start-guide/
     - title: "Aggregate Template"
-      url: /aggregate-template
+      url: /aggregate-template/
 - title: Creek components
   children:
     - title: "Descriptors"
-      url: /docs/descriptors
+      url: /docs/descriptors/
 - title: Extending Creek
   children:
     - title: "Existing extensions"

--- a/_docs/01-quick-start-guide.md
+++ b/_docs/01-quick-start-guide.md
@@ -12,14 +12,14 @@ If you're new to Creek, then we'd suggest one of this three approaches to gettin
 Ordered by simplicity, with the easiest at the top:
 
 1. **Try out a tutorial**. For example the Creek equivalent of a _Hello World_ app: the
-   [Basic Kafka Streams Tutorial](/basic-kafka-streams-demo),
-   or head on over to the [Tutorials page](/tutorials) for a full list, or
-2. **Use a template repository**: Dive into the Creek [aggregate template repository](/aggregate-template). 
+   [Basic Kafka Streams Tutorial](/basic-kafka-streams-demo/),
+   or head on over to the [Tutorials page](/tutorials/) for a full list, or
+2. **Use a template repository**: Dive into the Creek [aggregate template repository](/aggregate-template/). 
    Let the template do all the hard work of bootstrapping and configuring a new repository, 
    ready to develop, build and test your microservices, 
-   (how to use the template repo is covered in the [Basic Kafka Streams Tutorial](/basic-kafka-streams-demo)), or
-3. **Create your own template repository**: Clone and customise the Creek [aggregate template repository](/aggregate-template),
+   (how to use the template repo is covered in the [Basic Kafka Streams Tutorial](/basic-kafka-streams-demo/)), or
+3. **Create your own template repository**: Clone and customise the Creek [aggregate template repository](/aggregate-template/),
    to better meet your organisations needs.
 4. **Wait for docs**: Wait for use to get around to [writing docs for manually adding Creek to a repository](https://github.com/creek-service/creek-service.github.io/issues/30).
-5. **Unpick the aggregate template**: Use the Creek [aggregate template repository](/aggregate-template) as documentation 
+5. **Unpick the aggregate template**: Use the Creek [aggregate template repository](/aggregate-template/) as documentation 
    of how to manually add Creek to an existing project. 

--- a/_docs/20-descriptors.md
+++ b/_docs/20-descriptors.md
@@ -75,6 +75,6 @@ ensure the topic exists, and any schemas registered, when the service starts up 
 [creekKafka]: https://github.com/creek-service/creek-kafka
 [systemTest]: https://github.com/creek-service/creek-system-test
 [bcDDD]: https://martinfowler.com/bliki/BoundedContext.html
-[basicKsDemo]: {{ "/basic-kafka-streams-demo" | relative_url }}
+[basicKsDemo]: {{ "/basic-kafka-streams-demo/" | relative_url }}
 
 [todo]: http:// update links to docs, not repos, when docs exist

--- a/_posts/2022-11-21-basic-kafka-streams-demo-released.md
+++ b/_posts/2022-11-21-basic-kafka-streams-demo-released.md
@@ -12,7 +12,7 @@ tags:
 Following on from the [first public release of Creek]({% post_url 2022-11-15-v0.2.0-released %}), the first tutorial 
 is now available :smile:.
 
-The [Basic Kafka Streams Tutorial]({{ "/basic-kafka-streams-demo" | relative_url }}) gives a walk through of 
+The [Basic Kafka Streams Tutorial]({{ "/basic-kafka-streams-demo/" | relative_url }}) gives a walk through of 
 how Creek can help organisations quickly develop _and test_ a Kafka Streams based microservice.
 
 While working on the tutorial something that was thought complete was discovered not to be: code coverage reporting


### PR DESCRIPTION
Some urls used are being redirected as they don't end in a `/`, when they should.

### Reviewer checklist
 - [ ] Read the [contributing guide](https://github.com/creek-service/.github/blob/main/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
 - [ ] Ensure any appropriate documentation has been added or amended
